### PR TITLE
docs, add browser-sync tsd, use project local dep…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 This is a simple demo how to setup a project that uses TypeScript, Express 4, Angular 2, Sass 3, Gulp 3, jspm, BrowserSync, and nodemon.
 
+For server side live reloading, this project requires [nodemon](https://github.com/remy/nodemon)
+
 ## Installation
-
-For server side live reloading, this project requires (nodemon)[https://github.com/remy/nodemon]
-
 1. Clone this repository
 2. cd into the directory
 3. run `npm i`
@@ -17,20 +16,28 @@ For server side live reloading, this project requires (nodemon)[https://github.c
 
 Alternatively, for Linux based operating systems you can run `./scripts/setup.sh`
 
-## Deploy into production (with bundling)
+This will install your node dependencies, TypeScript definitions, will run an initial build, and will install frontend dependencies. 
+
+## Use bundled mode in production (with bundling, e.g. without http/2)
 1. run `jspm bundle app/app.component --inject`
 2. run the server with `node dist/server.js`
-3. The server is listening by default on `http://localhost:3000`
+3. The production server is now listening at `http://localhost:3000`
 
-This causes jspm to bundle the JavaScript (transpiled TypeScript) files into a single file,
-which significantly reduces the number of http requests, and initial load time, but is no good for dev.
+Alternatively, for Linux based operating systems you can run `./scripts/prod_bundled_server.sh`
 
-## Deploy into production (without bundling, e.g. for http/2)
-1. run `jspm unbundle`
+This causes jspm to bundle the JavaScript (transpiled from TypeScript) files into a single file,
+which significantly reduces the number of http requests and in HTTP 1, initial load time. It is not ideal for dev or HTTP/2.
+
+The `--inject` flag specifically makes sure to inject a script tag pointing to this new bundle into index.html. It is assumed that you have system.js and config.js already in your index.html page since TypeScript does not currently support self executing (sfx) bundling. Due to this limitation, we must call `jspm unbundle` when switching back and forth between bundled and unbundled mode. 
+
+## Use unbundled mode in production (without bundling, e.g. for http/2)
+1. run `jspm unbundle` 
 2. run the server with `node dist/server.js`
-3. The server is listening by default on `http://localhost:3000`
+3. The production server is now listening at `http://localhost:3000`
 
 Alternatively, for Linux based operating systems you can run `./scripts/prod_unbundled_server.sh`
+
+This takes any bundle configuration out of config so that multiple files will be used, this is the prefered configuration for http/2.
 
 ## Hack the code
 1. run `jspm unbundle`
@@ -38,15 +45,15 @@ Alternatively, for Linux based operating systems you can run `./scripts/prod_unb
 
 Alternatively, for Linux based operating systems you can run `./scripts/dev.sh`
 
-This causes jspm to unbundle, which makes hacking the code (developing) easier because
-only individual files need to be transpiled and built, and not the whole project.
+This causes jspm to unbundle any previous production bundle. This makes development easier because it ensures that only individual files need to be transpiled and built when you change them, and not the whole project.
 
-## Run dev server
-1. run the server with `nodemon dist/server.js`
-2. The live reloading server is listening by default on `http://localhost:3001` and the
+## Develop with Live Reload
+1. run `jspm unbundle`
+2. run the server with `nodemon dist/server.js`
+3. The live reloading server is listening at `http://localhost:3001` and the
 non-live reloading server is still available port 3000.
 
-Alternatively, for Linux based operating systems you can run `./scripts/dev.sh`
+Alternatively, for Linux based operating systems you can run `./scripts/dev_server.sh`
 
 ##Credits
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   "author": "Ben Kinsey",
   "license": "AGPL-3.0",
   "dependencies": {
-    "express": "^4.13.3"
+    "express": "^4.13.3",
+    "jspm": "^0.16.11",
+    "tsd": "^0.6.5"
   },
   "devDependencies": {
     "browser-sync": "^2.9.8",
@@ -39,7 +41,7 @@
     "gulp-sass": "^2.0.4",
     "gulp-typescript": "^2.8.1",
     "gulp-watch": "^4.3.5",
-    "jspm": "~0.16.6",
+    "nodemon": "^1.7.1",
     "run-sequence": "^1.1.2"
   },
   "jspm": {

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,6 +2,6 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`
 popd > /dev/null
 (cd $SCRIPTPATH/../ &&
-  jspm unbundle &&
-  gulp
+  $(npm bin)/jspm unbundle &&
+  $(npm bin)/gulp
 )

--- a/scripts/dev_server.sh
+++ b/scripts/dev_server.sh
@@ -2,6 +2,6 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`
 popd > /dev/null
 (cd $SCRIPTPATH/../ &&
-  jspm unbundle &&
-  nodemon dist/server.js
+  $(npm bin)/jspm unbundle &&
+  $(npm bin)/nodemon dist/server.js
 )

--- a/scripts/prod_bundled_server.sh
+++ b/scripts/prod_bundled_server.sh
@@ -2,6 +2,6 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`
 popd > /dev/null
 (cd $SCRIPTPATH/../ &&
-  jspm bundle app/app.component --inject &&
+  $(npm bin)/jspm bundle app/app.component --inject &&
   node dist/server.js
 )

--- a/scripts/prod_unbundled_server.sh
+++ b/scripts/prod_unbundled_server.sh
@@ -2,5 +2,6 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`
 popd > /dev/null
 (cd $SCRIPTPATH/../ &&
+  $(npm bin)/jspm unbundle &&
   node dist/server.js
 )

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ popd > /dev/null
 (cd $SCRIPTPATH/../ &&
   ./scripts/clean.sh && 
   npm i &&
-  tsd install &&
+  $(npm bin)/tsd install &&
   gulp build &&
-  jspm i
+  $(npm bin)/jspm i
 )

--- a/tsd.json
+++ b/tsd.json
@@ -34,6 +34,12 @@
     },
     "angular2/router.d.ts": {
       "commit": "98d3168c2c570352a3a7393788e2ec9fbb08ade6"
+    },
+    "browser-sync/browser-sync.d.ts": {
+      "commit": "05557455c49043ff0189182e27c9e04403a70802"
+    },
+    "chokidar/chokidar.d.ts": {
+      "commit": "05557455c49043ff0189182e27c9e04403a70802"
     }
   }
 }


### PR DESCRIPTION
This sets the scripts to use local nodemon jspm and tsd to avoid need for sudo access or global tools.
Updates the docs a bit
Adds the browser-sync tsd since ./scripts/dev.sh was throwing an error.
